### PR TITLE
Update task doesn't update documents bug was fixed

### DIFF
--- a/src/main/groovy/org/fundacionjala/gradle/plugins/enforce/utils/salesforce/PackageCombiner.groovy
+++ b/src/main/groovy/org/fundacionjala/gradle/plugins/enforce/utils/salesforce/PackageCombiner.groovy
@@ -4,8 +4,6 @@ import com.sforce.soap.metadata.PackageTypeMembers
 import org.fundacionjala.gradle.plugins.enforce.utils.Constants
 import org.fundacionjala.gradle.plugins.enforce.utils.Util
 
-import java.lang.reflect.Array
-
 class PackageCombiner {
     private static final ArrayList<String> SUB_COMPONENTS = ['CustomField', 'FieldSet', 'ValidationRule',
                                                              'CompactLayout', 'SharingReason', 'RecordType',
@@ -87,7 +85,7 @@ class PackageCombiner {
 
         getMembersByNameType(packageFromSourceFolder).each { String name, ArrayList<String> members ->
             if (COMPONENTS_WITH_SUB_FOLDERS.contains(name) && membersByNameOfPackageBuild.containsKey(name)
-                    && buildPackagePath.contains('package.xml')) {
+                    && buildPackagePath.contains(Constants.PACKAGE_FILE_NAME)) {
                 ArrayList<String> membersToUpdate = []
                 membersByNameOfPackageBuild.get(name).each {String membersFromPackageBuild ->
                     String folderName = Util.getFirstPath(membersFromPackageBuild)

--- a/src/main/groovy/org/fundacionjala/gradle/plugins/enforce/utils/salesforce/PackageCombiner.groovy
+++ b/src/main/groovy/org/fundacionjala/gradle/plugins/enforce/utils/salesforce/PackageCombiner.groovy
@@ -4,6 +4,8 @@ import com.sforce.soap.metadata.PackageTypeMembers
 import org.fundacionjala.gradle.plugins.enforce.utils.Constants
 import org.fundacionjala.gradle.plugins.enforce.utils.Util
 
+import java.lang.reflect.Array
+
 class PackageCombiner {
     private static final ArrayList<String> SUB_COMPONENTS = ['CustomField', 'FieldSet', 'ValidationRule',
                                                              'CompactLayout', 'SharingReason', 'RecordType',
@@ -84,9 +86,16 @@ class PackageCombiner {
         ArrayList<String> objectToDelete = []
 
         getMembersByNameType(packageFromSourceFolder).each { String name, ArrayList<String> members ->
-            if (COMPONENTS_WITH_SUB_FOLDERS.contains(name) && membersByNameOfPackageBuild.containsKey(name)) {
-                packageFromBuildFolder.removeMembers(name, membersByNameOfPackageBuild.get(name))
-                packageFromBuildFolder.update(name, members)
+            if (COMPONENTS_WITH_SUB_FOLDERS.contains(name) && membersByNameOfPackageBuild.containsKey(name)
+                    && buildPackagePath.contains('package.xml')) {
+                ArrayList<String> membersToUpdate = []
+                membersByNameOfPackageBuild.get(name).each {String membersFromPackageBuild ->
+                    String folderName = Util.getFirstPath(membersFromPackageBuild)
+                    if (members.contains(folderName)) {
+                        membersToUpdate.push(folderName)
+                    }
+                }
+                packageFromBuildFolder.update(name, membersToUpdate.unique())
             }
 
             if (SUB_COMPONENTS.contains(name) && membersByNameOfPackageBuild.containsKey(CUSTOM_OBJECT)) {

--- a/src/test/groovy/org/fundacionjala/gradle/plugins/enforce/utils/salesforce/PackageCombinerTest.groovy
+++ b/src/test/groovy/org/fundacionjala/gradle/plugins/enforce/utils/salesforce/PackageCombinerTest.groovy
@@ -408,7 +408,7 @@ class PackageCombinerTest extends Specification {
     def 'Test should take in account documents with their folders name as member into package xml file '() {
         given:
             String projectPackagePath = Paths.get(SRC_PATH, 'projectPackage.xml')
-            String buildPackagePath = Paths.get(SRC_PATH, 'buildPackage.xml')
+            String buildPackagePath = Paths.get(SRC_PATH, 'package.xml')
             String projectPackageContent = '''<?xml version='1.0' encoding='UTF-8'?>
                                     <Package xmlns='http://soap.sforce.com/2006/04/metadata'>
                                         <types>
@@ -476,18 +476,18 @@ class PackageCombinerTest extends Specification {
                                             <name>CustomObject</name>
                                         </types>
                                         <types>
+                                            <members>MyDocuments/doc2.txt</members>
+                                            <members>MyDocuments/doc1.txt</members>
+                                            <members>MyDocuments</members>
+                                            <name>Document</name>
+                                        </types>
+                                        <types>
                                             <members>Class1</members>
                                             <name>ApexClass</name>
                                         </types>
                                         <types>
                                             <members>Object1__c.MyCustomField1</members>
                                             <name>CustomField</name>
-                                        </types>
-                                        <types>
-                                            <members>MyDocuments</members>
-                                            <members>MyDocuments/doc2.txt</members>
-                                            <members>MyDocuments/doc1.txt</members>
-                                            <name>Document</name>
                                         </types>
                                         <types>
                                             <members>Object1__c.MyFieldSet1</members>
@@ -505,9 +505,105 @@ class PackageCombinerTest extends Specification {
             xmlDiff.similar()
     }
 
+    def 'Test should take in account documents with their folders name when it is added '() {
+        given:
+            String projectPackagePath = Paths.get(SRC_PATH, 'projectPackage.xml')
+            String buildPackagePath = Paths.get(SRC_PATH, 'package.xml')
+            //the next variable is content of my project package
+            String projectPackageContent = '''<?xml version='1.0' encoding='UTF-8'?>
+                                        <Package xmlns='http://soap.sforce.com/2006/04/metadata'>
+                                            <types>
+                                                <members>MyDocuments</members>
+                                                <members>MyDocuments/doc2.txt</members>
+                                                <members>MyDocuments/doc1.txt</members>
+                                                <name>Document</name>
+                                            </types>
+                                            <version>32.0</version>
+                                        </Package>
+                                        '''
+            //The next is the content of my build package
+            String buildPackageContent ='''<?xml version='1.0' encoding='UTF-8'?>
+                                        <Package xmlns='http://soap.sforce.com/2006/04/metadata'>
+                                            <types>
+                                                <members>MyDocuments/doc3.txt</members>
+                                                <name>Document</name>
+                                            </types>
+                                        <version>32.0</version></Package>
+                                        '''
+            File projectPackageFile = new File(projectPackagePath)
+            projectPackageFile.write(projectPackageContent)
+            File buildPackageFile = new File(buildPackagePath)
+            buildPackageFile.write(buildPackageContent)
+            String packageContentExpect = '''<?xml version='1.0' encoding='UTF-8'?>
+                                        <Package xmlns='http://soap.sforce.com/2006/04/metadata'>
+                                            <types>
+                                                <members>MyDocuments/doc3.txt</members>
+                                                <members>MyDocuments</members>
+                                                <name>Document</name>
+                                            </types>
+                                            <version>32.0</version>
+                                        </Package>
+                                        '''
+        when:
+            PackageCombiner.packageCombineToUpdate(projectPackagePath, buildPackagePath)
+            XMLUnit.ignoreWhitespace = true
+            def xmlDiff = new Diff(buildPackageFile.text, packageContentExpect)
+        then:
+            new File(Paths.get(SRC_PATH, 'buildPackage.xml').toString()).exists()
+            xmlDiff.similar()
+    }
+
+    def "Test shouldn't take in account documents with their folders name when it is deleted "() {
+        given:
+            String projectPackagePath = Paths.get(SRC_PATH, 'projectPackage.xml')
+            String destructivePath = Paths.get(SRC_PATH, 'destructiveChanges.xml')
+            //the next variable is content of my project package
+            String projectPackageContent = '''<?xml version='1.0' encoding='UTF-8'?>
+                                            <Package xmlns='http://soap.sforce.com/2006/04/metadata'>
+                                                <types>
+                                                    <members>MyDocuments</members>
+                                                    <members>MyDocuments/doc2.txt</members>
+                                                    <members>MyDocuments/doc1.txt</members>
+                                                    <name>Document</name>
+                                                </types>
+                                                <version>32.0</version>
+                                            </Package>
+                                            '''
+            //The next is the content of my build package
+            String destructiveContent ='''<?xml version='1.0' encoding='UTF-8'?>
+                                            <Package xmlns='http://soap.sforce.com/2006/04/metadata'>
+                                                <types>
+                                                    <members>MyDocuments/doc1.txt</members>
+                                                    <name>Document</name>
+                                                </types>
+                                            <version>32.0</version></Package>
+                                            '''
+            File projectPackageFile = new File(projectPackagePath)
+            projectPackageFile.write(projectPackageContent)
+            File buildPackageFile = new File(destructivePath)
+            buildPackageFile.write(destructiveContent)
+            String packageContentExpect = '''<?xml version='1.0' encoding='UTF-8'?>
+                                            <Package xmlns='http://soap.sforce.com/2006/04/metadata'>
+                                                <types>
+                                                    <members>MyDocuments/doc1.txt</members>
+                                                    <name>Document</name>
+                                                </types>
+                                                <version>32.0</version>
+                                            </Package>
+                                            '''
+        when:
+            PackageCombiner.packageCombineToUpdate(projectPackagePath, destructivePath)
+            XMLUnit.ignoreWhitespace = true
+            def xmlDiff = new Diff(buildPackageFile.text, packageContentExpect)
+        then:
+            new File(Paths.get(SRC_PATH, 'destructiveChanges.xml').toString()).exists()
+            xmlDiff.similar()
+    }
+
     def cleanupSpec() {
         new File(Paths.get(SRC_PATH, 'projectPackage.xml').toString()).delete()
         new File(Paths.get(SRC_PATH, 'buildPackage.xml').toString()).delete()
+        new File(Paths.get(SRC_PATH, 'destructiveChanges.xml').toString()).delete()
         new File(Paths.get(SRC_PATH, 'packageTest.xml').toString()).delete()
         new File(Paths.get(SRC_PATH, 'packageTestDocument.xml').toString()).delete()
         new File(Paths.get(SRC_PATH, 'packageTestReport.xml').toString()).delete()


### PR DESCRIPTION
Bug : "Once that a document is added and the update task is executed it didn't upload that document to your organization" and bug : "Once that a document is deleted and the update task is executed, it deletes all documents from your organization" were fixed.
