### PR TITLE
Add 'specificFiles' parameter to retrieve command

### DIFF
--- a/src/main/groovy/org/fundacionjala/gradle/plugins/enforce/metadata/RetrieveMetadata.groovy
+++ b/src/main/groovy/org/fundacionjala/gradle/plugins/enforce/metadata/RetrieveMetadata.groovy
@@ -31,7 +31,10 @@ public class RetrieveMetadata {
         this.metaPackage = metaPackage
         warningMessages = new ArrayList<String>()
     }
-
+    /**
+     * Allows define the files that will be downloaded in the Retrieve command's response.
+     * @param specificFiles, relative file paths with encoded names(URLEncoder).
+     */
     public void setSpecificFiles(ArrayList<String> specificFiles) {
         this.specificFiles = specificFiles
     }

--- a/src/main/groovy/org/fundacionjala/gradle/plugins/enforce/metadata/RetrieveMetadata.groovy
+++ b/src/main/groovy/org/fundacionjala/gradle/plugins/enforce/metadata/RetrieveMetadata.groovy
@@ -20,6 +20,7 @@ public class RetrieveMetadata {
     private org.fundacionjala.gradle.plugins.enforce.utils.salesforce.PackageManager.Package metaPackage
     private byte[] zipFileRetrieved
     private ArrayList<String> warningMessages
+    private ArrayList<String> specificFiles
     private String RETRIEVE_RESULT_NULL = "Retrieve result instance is NULL"
 
     /**
@@ -29,6 +30,10 @@ public class RetrieveMetadata {
     RetrieveMetadata(org.fundacionjala.gradle.plugins.enforce.utils.salesforce.PackageManager.Package metaPackage) {
         this.metaPackage = metaPackage
         warningMessages = new ArrayList<String>()
+    }
+
+    public void setSpecificFiles(ArrayList<String> specificFiles) {
+        this.specificFiles = specificFiles
     }
 
     /**
@@ -64,7 +69,7 @@ public class RetrieveMetadata {
         MetadataAPI metadataAPI = (MetadataAPI) ForceFactory.getForceAPI(ForceApiType.METADATA, credential)
         metadataAPI.poll = poll
         metadataAPI.waitTime = waitTime
-        RetrieveResult retrieveResult = metadataAPI.retrieve(metaPackage)
+        RetrieveResult retrieveResult = metadataAPI.retrieve(metaPackage, specificFiles)
         checkStatusSucceeded(retrieveResult)
         loadWarningsMessages(retrieveResult.getMessages())
         zipFileRetrieved = retrieveResult.getZipFile()

--- a/src/main/groovy/org/fundacionjala/gradle/plugins/enforce/tasks/salesforce/retrieve/Retrieval.groovy
+++ b/src/main/groovy/org/fundacionjala/gradle/plugins/enforce/tasks/salesforce/retrieve/Retrieval.groovy
@@ -65,7 +65,7 @@ abstract class Retrieval extends SalesforceTask {
             if (Util.isValidProperty(project, FILES_RETRIEVE)) {
                 files = project.property(FILES_RETRIEVE) as String
             }
-            specificFiles = project.hasProperty(SPECIFIC_FILES_RETRIEVE);
+            specificFiles = project.hasProperty(SPECIFIC_FILES_RETRIEVE)
         }
         if (Util.isValidProperty(project, ALL_PARAMETER)) {
             all = project.property(ALL_PARAMETER) as String
@@ -129,14 +129,18 @@ abstract class Retrieval extends SalesforceTask {
         println "*********************************************\t"
         if (classifiedFile.validFiles) {
             classifiedFile.validFiles.each { file ->
-                String fileNameToRetrieve = getSpecificFileFormattedName(file);
+                String fileNameToRetrieve = getSpecificFileFormattedName(file)
                 println(fileNameToRetrieve)
-                specificFileNames.add(fileNameToRetrieve);
+                specificFileNames.add(fileNameToRetrieve)
             }
         }
         println "*********************************************\t"
     }
 
+    /**
+     * Returns file's relative path and applies URLEncoder to file names, it is in order to ensure safe SOAP requests.
+     * @return String, relative path with encoded name.
+     */
     String getSpecificFileFormattedName(File file) {
         String fileName = file.getName()
         String fileNameToRetrieve = file.getAbsolutePath().replace(projectPath, "").replace(fileName, URLEncoder.encode(fileName, "UTF-8"))

--- a/src/main/groovy/org/fundacionjala/gradle/plugins/enforce/tasks/salesforce/retrieve/Retrieval.groovy
+++ b/src/main/groovy/org/fundacionjala/gradle/plugins/enforce/tasks/salesforce/retrieve/Retrieval.groovy
@@ -4,29 +4,36 @@
  */
 
 package org.fundacionjala.gradle.plugins.enforce.tasks.salesforce.retrieve
-
 import org.fundacionjala.gradle.plugins.enforce.metadata.RetrieveMetadata
 import org.fundacionjala.gradle.plugins.enforce.tasks.salesforce.SalesforceTask
 import org.fundacionjala.gradle.plugins.enforce.utils.Constants
 import org.fundacionjala.gradle.plugins.enforce.utils.Util
 import org.fundacionjala.gradle.plugins.enforce.utils.ZipFileManager
+import org.fundacionjala.gradle.plugins.enforce.utils.salesforce.ClassifiedFile
+import org.fundacionjala.gradle.plugins.enforce.utils.salesforce.FileValidator
 import org.fundacionjala.gradle.plugins.enforce.utils.salesforce.PackageManager.Package
 import org.fundacionjala.gradle.plugins.enforce.utils.salesforce.PackageManager.PackageBuilder
+import org.fundacionjala.gradle.plugins.enforce.utils.salesforce.filter.Filter
 
 import java.nio.file.Paths
 
 abstract class Retrieval extends SalesforceTask {
     private final String ZIP_FILE_NAME = 'retrieve.zip'
     private final String UNPACKAGE_FOLDER = 'unpackaged'
+    private final String SPECIFIC_FILES_NOT_FOUND = "Valid files were not found, retrieve task was canceled!!"
+    protected final int CODE_TO_EXIT = 0
     public RetrieveMetadata retrieveMetadata
     public PackageBuilder packageBuilder
     public String unPackageFolder
     public String packageFromSourcePath
     public String packageFromBuildPath
     private final String FILES_RETRIEVE = 'files'
+    private final String SPECIFIC_FILES_RETRIEVE = 'specificFiles'
     private final String ALL_PARAMETER = 'all'
     public String files
     public String all = Constants.FALSE
+    public Boolean specificFiles = Constants.FALSE
+    public ArrayList<String> specificFileNames
 
     /**
      * Sets description and group task
@@ -58,6 +65,7 @@ abstract class Retrieval extends SalesforceTask {
             if (Util.isValidProperty(project, FILES_RETRIEVE)) {
                 files = project.property(FILES_RETRIEVE) as String
             }
+            specificFiles = project.hasProperty(SPECIFIC_FILES_RETRIEVE);
         }
         if (Util.isValidProperty(project, ALL_PARAMETER)) {
             all = project.property(ALL_PARAMETER) as String
@@ -69,6 +77,10 @@ abstract class Retrieval extends SalesforceTask {
      */
     void executeRetrieve(Package metaPackage) {
         retrieveMetadata = new RetrieveMetadata(metaPackage)
+        if (specificFiles) {
+            readSpecificFilesToRetrieve()
+            retrieveMetadata.setSpecificFiles(specificFileNames)
+        }
         retrieveMetadata.executeRetrieve(poll, waitTime, credential)
     }
 
@@ -79,7 +91,11 @@ abstract class Retrieval extends SalesforceTask {
     void saveOnDiskFileUnzipped(byte[] zipFile) {
         ZipFileManager zipFileManager = new ZipFileManager()
         zipFileManager.flushZipFile(zipFile, buildFolderPath, ZIP_FILE_NAME)
-        unZip(Paths.get(buildFolderPath, ZIP_FILE_NAME).toString(), buildFolderPath)
+        if (!specificFiles) {
+            unZip(Paths.get(buildFolderPath, ZIP_FILE_NAME).toString(), buildFolderPath)
+        } else {
+            unZip(Paths.get(buildFolderPath, ZIP_FILE_NAME).toString(), projectPath)
+        }
     }
 
     /**
@@ -92,5 +108,38 @@ abstract class Retrieval extends SalesforceTask {
         retrieveMetadata.getWarningsMessages().each { message ->
             logger.warn(message)
         }
+    }
+    /**
+     * Loads specific files to be retrieved, their file names must be encoded by URLEncoder logic in order to avoid SOAP exceptions.
+     **/
+    void readSpecificFilesToRetrieve() {
+        specificFileNames = []
+        Filter filter = new Filter(project, projectPath)
+        ClassifiedFile classifiedFile = null
+        if (files) {
+            ArrayList<File> filesFiltered = filter.getFiles(files, null)
+            classifiedFile = FileValidator.validateFiles(projectPath, filesFiltered)
+        }
+        if (!classifiedFile || !classifiedFile.validFiles || classifiedFile.validFiles.isEmpty()) {
+            logger.error(SPECIFIC_FILES_NOT_FOUND)
+            System.exit(CODE_TO_EXIT)
+        }
+        println "*********************************************\t"
+        println "        Specific files to retrieve\t"
+        println "*********************************************\t"
+        if (classifiedFile.validFiles) {
+            classifiedFile.validFiles.each { file ->
+                String fileNameToRetrieve = getSpecificFileFormattedName(file);
+                println(fileNameToRetrieve)
+                specificFileNames.add(fileNameToRetrieve);
+            }
+        }
+        println "*********************************************\t"
+    }
+
+    String getSpecificFileFormattedName(File file) {
+        String fileName = file.getName()
+        String fileNameToRetrieve = file.getAbsolutePath().replace(projectPath, "").replace(fileName, URLEncoder.encode(fileName, "UTF-8"))
+        return fileNameToRetrieve.substring(1).replaceAll("\\\\", "/")
     }
 }

--- a/src/main/groovy/org/fundacionjala/gradle/plugins/enforce/tasks/salesforce/retrieve/Retrieve.groovy
+++ b/src/main/groovy/org/fundacionjala/gradle/plugins/enforce/tasks/salesforce/retrieve/Retrieve.groovy
@@ -4,14 +4,12 @@
  */
 
 package org.fundacionjala.gradle.plugins.enforce.tasks.salesforce.retrieve
-
 import org.fundacionjala.gradle.plugins.enforce.utils.Constants
 import org.fundacionjala.gradle.plugins.enforce.utils.ManagementFile
 import org.fundacionjala.gradle.plugins.enforce.utils.Util
 import org.fundacionjala.gradle.plugins.enforce.utils.salesforce.PackageManager.PackageBuilder
 
 import java.nio.file.Paths
-
 /**
  * Retrieves elements from organization according parameters inserted by user
  */
@@ -25,7 +23,6 @@ class Retrieve extends Retrieval {
     private final String DESTINATION_FOLDER = 'destination'
     private String option
     public String destination
-    public final int CODE_TO_EXIT = 0
 
     ArrayList<File> filesToRetrieve
 
@@ -45,7 +42,13 @@ class Retrieve extends Retrieval {
         loadFilesToRetrieve()
         ManagementFile.createDirectories(projectPath)
         Util.validateContentParameter(projectPath, files)
-        !hasPackage() && !files ? retrieveWithoutPackageXml() : retrieveWithPackageXml()
+        if (specificFiles) {
+            retrieveWithSpecificFiles()
+        } else if (!hasPackage() && !files) {
+            retrieveWithoutPackageXml()
+        } else {
+            retrieveWithPackageXml()
+        }
         deleteTemporaryFiles()
     }
 
@@ -123,6 +126,14 @@ class Retrieve extends Retrieval {
         PackageBuilder.updatePackageXml(packageFromBuildPath, packageFromSourcePath)
         File unpackage = new File(unPackageFolder)
         unpackage.deleteDir()
+    }
+
+    /**
+     * Executes the logic to retrieve specific files defined on -Pfiles parameter and based on the users package.xml file.
+     */
+    void retrieveWithSpecificFiles() {
+        loadFromPackage()
+        runRetrieve()
     }
 
     /**

--- a/src/main/groovy/org/fundacionjala/gradle/plugins/enforce/utils/salesforce/filter/FilterSubcomponents.groovy
+++ b/src/main/groovy/org/fundacionjala/gradle/plugins/enforce/utils/salesforce/filter/FilterSubcomponents.groovy
@@ -94,7 +94,7 @@ class FilterSubcomponents {
         def folderPath  = Util.getFirstPath(relativePath)
         def component = MetadataComponents.getComponentByFolder(folderPath)
         if (!component) {
-            println('ComponentNotFound: ' + relativePath);
+            println('ComponentNotFound: ' + relativePath)
         } else if(components.contains(component) || !supportedSubcomponents.contains(component.getDirectory())) {
             return true
         }

--- a/src/main/groovy/org/fundacionjala/gradle/plugins/enforce/utils/salesforce/filter/FilterSubcomponents.groovy
+++ b/src/main/groovy/org/fundacionjala/gradle/plugins/enforce/utils/salesforce/filter/FilterSubcomponents.groovy
@@ -93,7 +93,9 @@ class FilterSubcomponents {
         def relativePath = Util.getRelativePath(file, projectPath)
         def folderPath  = Util.getFirstPath(relativePath)
         def component = MetadataComponents.getComponentByFolder(folderPath)
-        if(components.contains(component) || !supportedSubcomponents.contains(component.getDirectory())) {
+        if (!component) {
+            println('ComponentNotFound: ' + relativePath);
+        } else if(components.contains(component) || !supportedSubcomponents.contains(component.getDirectory())) {
             return true
         }
         return false

--- a/src/main/groovy/org/fundacionjala/gradle/plugins/enforce/wsc/soap/MetadataAPI.groovy
+++ b/src/main/groovy/org/fundacionjala/gradle/plugins/enforce/wsc/soap/MetadataAPI.groovy
@@ -116,7 +116,7 @@ class MetadataAPI extends ForceAPI {
         retrieveRequest.setUnpackaged(metaPackage)
         if (specificFiles && !specificFiles.isEmpty()) {
             retrieveRequest.setSpecificFiles(specificFiles.toArray() as String[])
-            retrieveRequest.setSinglePackage(true);
+            retrieveRequest.setSinglePackage(true)
         }
         println STARTING_RETRIEVE
         AsyncResult asyncResult = metadataConnection.retrieve(retrieveRequest)

--- a/src/main/groovy/org/fundacionjala/gradle/plugins/enforce/wsc/soap/MetadataAPI.groovy
+++ b/src/main/groovy/org/fundacionjala/gradle/plugins/enforce/wsc/soap/MetadataAPI.groovy
@@ -108,8 +108,16 @@ class MetadataAPI extends ForceAPI {
      * @return the retrieve result
      */
     public RetrieveResult retrieve(Package metaPackage) {
+        retrieve(metaPackage, null)
+    }
+
+    public RetrieveResult retrieve(Package metaPackage, ArrayList<String> specificFiles) {
         RetrieveRequest retrieveRequest = new RetrieveRequest()
         retrieveRequest.setUnpackaged(metaPackage)
+        if (specificFiles && !specificFiles.isEmpty()) {
+            retrieveRequest.setSpecificFiles(specificFiles.toArray() as String[])
+            retrieveRequest.setSinglePackage(true);
+        }
         println STARTING_RETRIEVE
         AsyncResult asyncResult = metadataConnection.retrieve(retrieveRequest)
         println WAITING_RETRIEVE


### PR DESCRIPTION
It is in order to retrieve components with the user's package.xml file
in the Retrieve Request and only download the files/folders defined on 'files'
parameter. E.G. Common use case: Retrieve profiles and permissionsets.
