### PR TITLE
#273: Adding deployment validation task

### DIFF
--- a/src/main/groovy/org/fundacionjala/gradle/plugins/enforce/EnforcePlugin.groovy
+++ b/src/main/groovy/org/fundacionjala/gradle/plugins/enforce/EnforcePlugin.groovy
@@ -16,6 +16,7 @@ import org.fundacionjala.gradle.plugins.enforce.tasks.salesforce.deployment.Unde
 import org.fundacionjala.gradle.plugins.enforce.tasks.salesforce.deployment.Update
 import org.fundacionjala.gradle.plugins.enforce.tasks.salesforce.deployment.Upload
 import org.fundacionjala.gradle.plugins.enforce.tasks.salesforce.deployment.Delete
+import org.fundacionjala.gradle.plugins.enforce.tasks.salesforce.deployment.Validate
 import org.fundacionjala.gradle.plugins.enforce.tasks.salesforce.execute.ApexExecutor
 import org.fundacionjala.gradle.plugins.enforce.tasks.salesforce.managepackage.InstallPackageTask
 import org.fundacionjala.gradle.plugins.enforce.tasks.salesforce.managepackage.UninstallPackageTask
@@ -54,6 +55,7 @@ class EnforcePlugin implements Plugin<Project> {
         project.task('upload', type: Upload)
         project.task('delete', type: Delete)
         project.task('truncate', type: Truncate)
+        project.task('validate', type: Validate)
 
         project.task("addCredential", type: CredentialAdder)
         project.task("updateCredential", type: CredentialUpdater)

--- a/src/main/groovy/org/fundacionjala/gradle/plugins/enforce/metadata/DeployMetadata.groovy
+++ b/src/main/groovy/org/fundacionjala/gradle/plugins/enforce/metadata/DeployMetadata.groovy
@@ -31,16 +31,16 @@ class DeployMetadata {
         startMessage = START_MESSAGE
         successMessage = SUCCESS_MESSAGE
     }
+
     /**
      * Deploys an org using metadata API in the source path specified
      */
-    void deploy(int poll, int waitTime, Credential credential, String apiVersion) {
-
-        MetadataAPI metadataAPI =  new MetadataAPI(credential, new Connector(credential.loginFormat, apiVersion))
+    void deploy(int poll, int waitTime, Credential credential, String apiVersion, boolean checkOnly) {
+        MetadataAPI metadataAPI = new MetadataAPI(credential, new Connector(credential.loginFormat, apiVersion))
         metadataAPI.poll = poll
         metadataAPI.waitTime = waitTime
         println startMessage
-        DeployResult deployResult = metadataAPI.deploy(path)
+        DeployResult deployResult = metadataAPI.deploy(path, checkOnly)
         checkStatusDeploy(deployResult)
     }
 

--- a/src/main/groovy/org/fundacionjala/gradle/plugins/enforce/tasks/salesforce/deployment/Deployment.groovy
+++ b/src/main/groovy/org/fundacionjala/gradle/plugins/enforce/tasks/salesforce/deployment/Deployment.groovy
@@ -36,6 +36,7 @@ abstract class Deployment extends SalesforceTask {
     public String taskPackagePath
     public String taskDestructivePath
     ClassifiedFile classifiedFile
+    protected boolean checkOnly
 
     /**
      * Sets description and group task
@@ -44,6 +45,7 @@ abstract class Deployment extends SalesforceTask {
      */
     Deployment(String descriptionTask, String groupTask) {
         super(descriptionTask, groupTask)
+        checkOnly = false
         componentDeploy = new DeployMetadata()
         interceptorManager = new InterceptorManager()
         interceptorManager.encoding = project.property(Constants.FORCE_EXTENSION).encoding
@@ -51,9 +53,9 @@ abstract class Deployment extends SalesforceTask {
     }
 
     /**
-     * Executes deploy action
+     * Executes generic deploy action
      */
-    def executeDeploy(String sourcePath, String startMessage, String successMessage) {
+    public def executeDeploy(String sourcePath, String startMessage, String successMessage) {
         String fileName = new File(sourcePath).getName()
         logger.debug("Creating zip file at: $buildFolderPath$File.separator$fileName")
         componentDeploy.startMessage = startMessage
@@ -62,8 +64,8 @@ abstract class Deployment extends SalesforceTask {
         componentDeploy.setPath(pathZipToDeploy)
         logger.debug('Deploying components')
         String apiVersion = PackageComponent.getApiVersion(projectPackagePath) < Connector.API_VERSION?
-                            Connector.API_VERSION : PackageComponent.getApiVersion(projectPackagePath)
-        componentDeploy.deploy(poll, waitTime, credential, apiVersion)
+                Connector.API_VERSION : PackageComponent.getApiVersion(projectPackagePath)
+        componentDeploy.deploy(poll, waitTime, credential, apiVersion, checkOnly)
         deleteTemporaryFiles()
     }
 

--- a/src/main/groovy/org/fundacionjala/gradle/plugins/enforce/tasks/salesforce/deployment/Validate.groovy
+++ b/src/main/groovy/org/fundacionjala/gradle/plugins/enforce/tasks/salesforce/deployment/Validate.groovy
@@ -1,0 +1,25 @@
+package org.fundacionjala.gradle.plugins.enforce.tasks.salesforce.deployment
+
+import org.fundacionjala.gradle.plugins.enforce.utils.Constants
+
+/**
+ * Deploy performing validation in all project source
+ */
+class Validate extends Deploy {
+    private static final String VALIDATING_CODE = 'Starting validation'
+
+    /**
+     * Sets description task and its group
+     */
+    Validate() {
+        super()
+        this.description = VALIDATING_CODE
+        this.group = Constants.DEPLOYMENT
+    }
+
+    @Override
+    void runTask() {
+        checkOnly = true
+        super.runTask()
+    }
+}

--- a/src/main/groovy/org/fundacionjala/gradle/plugins/enforce/wsc/soap/MetadataAPI.groovy
+++ b/src/main/groovy/org/fundacionjala/gradle/plugins/enforce/wsc/soap/MetadataAPI.groovy
@@ -82,12 +82,21 @@ class MetadataAPI extends ForceAPI {
     }
 
     /**
-     * Deploys asynchronously all salesforce components from a zip file
+     * Deploys asynchronously all salesforce components from a zip file without performing any validation
      * @param sourcePath the zip file to deploy
      * @return the deploy result obtained from server
      */
-    public DeployResult deploy(String sourcePath) {
+    public DeployResult deploy(String sourcePath, boolean checkOnly) {
+        return genericDeploy(sourcePath, checkOnly)
+    }
 
+    /**
+     * Deploys asynchronously all salesforce components from a zip file
+     * @param sourcePath the zip file to deploy
+     * @param checkOnly whether or not to perform a validation
+     * @return the deploy result obtained from server
+     */
+    private DeployResult genericDeploy(String sourcePath, boolean checkOnly) {
         def byteArray = new File(sourcePath).getBytes()
         DeployOptions deployOptions = new DeployOptions()
         deployOptions.setPerformRetrieve(false)
@@ -96,6 +105,7 @@ class MetadataAPI extends ForceAPI {
         deployOptions.setAllowMissingFiles(true)
         deployOptions.setPurgeOnDelete(true)
         deployOptions.setIgnoreWarnings(false)
+        deployOptions.setCheckOnly(checkOnly)
         AsyncResult asyncResult = metadataConnection.deploy(byteArray, deployOptions)
         DeployResult deployResult = inspectorResults.waitForDeployResult(asyncResult.id, poll, waitTime * THOUSAND)
 

--- a/src/test/groovy/org/fundacionjala/gradle/plugins/enforce/tasks/salesforce/deployment/ValidateTest.groovy
+++ b/src/test/groovy/org/fundacionjala/gradle/plugins/enforce/tasks/salesforce/deployment/ValidateTest.groovy
@@ -1,0 +1,59 @@
+package org.fundacionjala.gradle.plugins.enforce.tasks.salesforce.deployment
+
+import org.fundacionjala.gradle.plugins.enforce.EnforcePlugin
+import org.fundacionjala.gradle.plugins.enforce.metadata.DeployMetadata
+import org.fundacionjala.gradle.plugins.enforce.utils.ManagementFile
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.nio.file.Paths
+
+class ValidateTest extends Specification {
+    @Shared
+    Project project
+
+    @Shared
+    def instanceDeploy
+
+    def deployMetadata = Mock(DeployMetadata)
+
+    @Shared
+    def SRC_PATH = Paths.get(System.getProperty("user.dir"), "src", "test", "groovy", "org",
+            "fundacionjala", "gradle", "plugins","enforce","tasks", "salesforce", "resources").toString()
+
+    def setup() {
+        project = ProjectBuilder.builder().build()
+        project.apply(plugin: EnforcePlugin)
+        project.enforce.srcPath = SRC_PATH
+        instanceDeploy = project.tasks.validate
+        instanceDeploy.fileManager = new ManagementFile(SRC_PATH)
+        instanceDeploy.project.enforce.deleteTemporaryFiles = false
+        instanceDeploy.createDeploymentDirectory(Paths.get(SRC_PATH, 'build').toString())
+        instanceDeploy.createDeploymentDirectory(Paths.get(SRC_PATH, 'build', 'deploy').toString())
+        instanceDeploy.createDeploymentDirectory(Paths.get(SRC_PATH, 'build', 'deploy', 'folderOne').toString())
+        instanceDeploy.componentDeploy = deployMetadata
+    }
+
+    def "should perform validation"() {
+        given:
+        instanceDeploy.buildFolderPath = Paths.get(SRC_PATH, 'build').toString()
+        instanceDeploy.projectPath = Paths.get(SRC_PATH, 'src').toString()
+        instanceDeploy.project.enforce.deleteTemporaryFiles = true
+        instanceDeploy.projectPackagePath = Paths.get(SRC_PATH, 'src', 'package.xml').toString()
+        String folderDeploy = Paths.get(SRC_PATH, 'build', 'deploy').toString()
+
+        and:
+        instanceDeploy.setup()
+        instanceDeploy.createDeploymentDirectory(folderDeploy)
+        instanceDeploy.displayFolderNoDeploy()
+        instanceDeploy.deployAllComponents()
+        instanceDeploy.deleteTemporaryFiles()
+
+        when:
+            instanceDeploy.runTask()
+        then:
+            2 * deployMetadata.deploy(_, _, _, _, true)
+    }
+}


### PR DESCRIPTION
This new Task is to validate the deployment. Your changes should be reverted after the validation ends.

Propose way to execute it:

gradle validate

and you can use all the deploy arguments likes include and excludes.
