### PR TITLE
#275: Adding support to upload and retrieve ExternalDataSources

### DIFF
--- a/src/main/groovy/org/fundacionjala/gradle/plugins/enforce/utils/salesforce/MetadataComponents.groovy
+++ b/src/main/groovy/org/fundacionjala/gradle/plugins/enforce/utils/salesforce/MetadataComponents.groovy
@@ -74,7 +74,8 @@ public enum MetadataComponents {
     LISTVIEWS("ListView", "sbc", "listViews"),
     SHARINGREASON("SharingReason", "sbc", "SharingReason"),
     OBJECTWEBLINKS("Weblink", "sbc", "webLinks"),
-    CUSTOMPERMISSIONS("CustomPermission", "customPermission", "customPermissions")
+    CUSTOMPERMISSIONS("CustomPermission", "customPermission", "customPermissions"),
+    EXTERNALDATASOURCE("ExternalDataSource", "dataSource", "dataSources")
 
     public final static Map<String, MetadataComponents> COMPONENT
 

--- a/src/test/groovy/org/fundacionjala/gradle/plugins/enforce/utils/salesforce/MetadataComponentsTest.groovy
+++ b/src/test/groovy/org/fundacionjala/gradle/plugins/enforce/utils/salesforce/MetadataComponentsTest.groovy
@@ -63,7 +63,7 @@ class MetadataComponentsTest extends Specification {
     def "Test enum name is equals to directory name"() {
         expect:
             MetadataComponents.COMPONENT.each {key, value->
-                if(value.extension != 'sbc' && value.directory != 'aura') {
+                if(value.extension != 'sbc' && value.directory != 'aura' && value.directory != 'dataSources') {
                     assert key == value.directory.toUpperCase()
                 }
             }
@@ -72,6 +72,16 @@ class MetadataComponentsTest extends Specification {
     def "Test get a CustomPermission extension"() {
         expect:
             MetadataComponents.getComponent("customPermissions").getExtension() == "customPermission"
+    }
+
+    def "Test get a ExternalDataSource extension"() {
+        expect:
+        MetadataComponents.getComponent("ExternalDataSource").getExtension() == "dataSource"
+    }
+
+    def "Test get a ExternalDataSource by folder"() {
+        expect:
+        MetadataComponents.getComponentByPath("dataSources").typeName == "ExternalDataSource"
     }
 
     def "Test a component by folder"() {


### PR DESCRIPTION
Add support to deploy External DataSources.

However there are some consideration to take in mind.
If you define an external Datasource using a Custom Provider, which means that you implemented a class to resolve all the connections etc.
And we try to execute: gradle deploy
it will fail because Salesforce is not able to resolve the reference that is declared in the .dataSource file.

The workaround that I found is break the deployment in two steps:
gradle deploy -Pexcludes=dataSources
gradle deploy -Pfolders=dataSources

In this way everything works fine.

Hope that you find useful this.
Any suggestions is welcome
