### PR TITLE
Fixed 'INVALID_OPERATION' error

### DIFF
--- a/src/main/groovy/org/fundacionjala/gradle/plugins/enforce/tasks/salesforce/unittest/RunTestTask.groovy
+++ b/src/main/groovy/org/fundacionjala/gradle/plugins/enforce/tasks/salesforce/unittest/RunTestTask.groovy
@@ -145,7 +145,9 @@ class RunTestTask extends SalesforceTask {
             logger.quiet(RunTestTaskConstants.ALL_UNIT_TEST_WILL_BE_EXECUTED)
             request.allTests = true
         }
-        request.namespace = toolingAPI.getPrefixName()
+        if (!request.allTests) {
+            request.namespace = toolingAPI.getPrefixName()
+        }
         logger.log(LogLevel.INFO, String.format(RunTestTaskConstants.START_TIME, new Date().format(RunTestTaskConstants.HOUR_FORMAT)))
         RunTestsResult runTestResult = apexAPI.runTests(request)
 


### PR DESCRIPTION
> 'INVALID_OPERATION: When specifying run-all-tests do not also specify a namespace prefix or class names'

This error message is displayed when runTest task is executed over a SFDC org with namespace enabled. Added validation to avoid set namespace property if allTests flag is 'true'.
